### PR TITLE
Add .gitattributes for Dockerfile syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Dockerfile.* linguist-language=Dockerfile


### PR DESCRIPTION
## Summary
- Add `.gitattributes` to set `linguist-language=Dockerfile` for `Dockerfile.*` pattern
- This enables syntax highlighting for `Dockerfile.dev` and `Dockerfile.release` on GitHub

## Test plan
- [ ] Verify `Dockerfile.dev` and `Dockerfile.release` show Dockerfile syntax highlighting on GitHub after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)