### PR TITLE
Update Dockerfile.dev SSH socket path and remove Redis extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -35,8 +35,6 @@
     //
     // https://marketplace.visualstudio.com/items?itemName=dbankier.vscode-quick-select
     "dbankier.vscode-quick-select",
-    // https://marketplace.visualstudio.com/items?itemName=Redis.redis-for-vscode
-    "Redis.redis-for-vscode",
     // https://marketplace.visualstudio.com/items?itemName=timonwong.shellcheck
     "timonwong.shellcheck",
     // https://marketplace.visualstudio.com/items?itemName=usernamehw.errorlens

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -21,7 +21,7 @@
 #
 # Run the Docker container:
 #
-# Start the Docker container(/run/host-services/ssh-auth.sock is a virtual socket provided by Docker Desktop for Mac.):
+# Start the Docker container(/run/host-services/ssh-auth.sock is a virtual socket provided by Docker Desktop for Mac and OrbStack.):
 #
 #   docker container run -d --rm --init -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock -e SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock -e GH_TOKEN=$(gh auth token) --mount type=bind,src=`pwd`,dst=/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-container $PROJECT-image
 #

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -23,7 +23,7 @@
 #
 # Start the Docker container(/run/host-services/ssh-auth.sock is a virtual socket provided by Docker Desktop for Mac and OrbStack.):
 #
-#   docker container run -d --rm --init -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock -e SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock -e GH_TOKEN=$(gh auth token) --mount type=bind,src=`pwd`,dst=/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-container $PROJECT-image
+#   docker container run -d --rm --init -v /run/host-services/ssh-auth.sock:/agent.sock -e SSH_AUTH_SOCK=/agent.sock -e GH_TOKEN=$(gh auth token) --mount type=bind,src=`pwd`,dst=/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-container $PROJECT-image
 #
 # Log into the container.
 #


### PR DESCRIPTION
## Summary
- Update SSH agent socket mount path in Dockerfile.dev to use `/agent.sock` instead of `/run/host-services/ssh-auth.sock` inside the container, fixing compatibility with OrbStack
- Add OrbStack mention to the SSH agent socket comment in Dockerfile.dev
- Remove unused Redis for VSCode extension from `.vscode/extensions.json`

## Test plan
- [ ] Verify Docker container starts correctly with the new SSH socket path on both Docker Desktop for Mac and OrbStack
- [ ] Confirm SSH agent forwarding works inside the container (`ssh-add -l`)
- [ ] Verify VS Code extensions load without issues after removing the Redis extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)