### PR TITLE
Adopt unified Docker tag naming convention (Proposal C)

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,7 +9,7 @@
 #
 # Build the Docker image:
 #
-#   PROJECT=$(basename `pwd`) && docker image build -f Dockerfile.dev -t $PROJECT-image . --build-arg user_id=`id -u` --build-arg group_id=`id -g`
+#   PROJECT=$(basename `pwd`) && docker image build -f Dockerfile.dev -t ${PROJECT}:dev . --build-arg user_id=`id -u` --build-arg group_id=`id -g`
 #
 # (First time only) Create a volume for command history:
 #
@@ -23,7 +23,7 @@
 #
 # Start the Docker container(/run/host-services/ssh-auth.sock is a virtual socket provided by Docker Desktop for Mac and OrbStack.):
 #
-#   docker container run -d --rm --init -v /run/host-services/ssh-auth.sock:/agent.sock -e SSH_AUTH_SOCK=/agent.sock -e GH_TOKEN=$(gh auth token) --mount type=bind,src=`pwd`,dst=/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-container $PROJECT-image
+#   docker container run -d --rm --init -v /run/host-services/ssh-auth.sock:/agent.sock -e SSH_AUTH_SOCK=/agent.sock -e GH_TOKEN=$(gh auth token) --mount type=bind,src=`pwd`,dst=/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-dev-container ${PROJECT}:dev
 #
 # Log into the container.
 #

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -8,15 +8,15 @@
 #
 # Build the Docker image:
 #
-#   docker image build -f Dockerfile.release -t hello-python-uv-release .
+#   PROJECT=$(basename `pwd`) && VERSION=$(cat VERSION) && docker image build -f Dockerfile.release -t ${PROJECT}:${VERSION} -t ${PROJECT}:latest .
 #
 # Run the Docker container:
 #
-#   docker container run --rm hello-python-uv-release
+#   PROJECT=$(basename `pwd`) && docker container run --rm ${PROJECT}:latest
 #
 # Run a different script:
 #
-#   docker container run --rm hello-python-uv-release python scripts/use-git-library.py
+#   docker container run --rm ${PROJECT}:latest python scripts/use-git-library.py
 #
 
 # ----------------------------------------------------------


### PR DESCRIPTION
## Summary

- Dockerfile.dev / Dockerfile.release のイメージタグ命名を提案C（同一リポジトリ名 + タグで用途を区別）に統一
- `$PROJECT-image` / `hello-python-uv-release` → `${PROJECT}:dev` / `${PROJECT}:${VERSION}` + `${PROJECT}:latest`
- zsh のコロン修飾子（`:l` = lowercase）による誤展開を防ぐため `${VAR}` 形式を使用

## Test plan

- [x] `Dockerfile.release` のビルドコマンドで `hello_python_uv:1.2.1` と `hello_python_uv:latest` が正しくタグ付けされることを確認
- [x] `docker container run --rm ${PROJECT}:latest` でコンテナが正常に実行されることを確認
- [x] `docker image ls hello_python_uv` で dev/release イメージを一覧できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)